### PR TITLE
Add France Chapter Talk Series seminar: Prof. Saeid Saidi (May 12, 2026)

### DIFF
--- a/content/events/2026-05-france-talk-saidi.en.md
+++ b/content/events/2026-05-france-talk-saidi.en.md
@@ -1,0 +1,37 @@
+---
+title: "France Chapter Talk Series — Prof. Saeid Saidi"
+date: 2026-05-12
+draft: false
+description: "IEEE ITSS France Chapter Talk Series: Recent Advances in Public Transit Operations, Control, and Planning by Prof. Saeid Saidi. May 12, 2026, Hybrid."
+event_date: "May 12, 2026 (Tue) 21:00 KST / 14:00 CEST"
+location: "Hybrid — Université Gustave Eiffel (Marne-la-Vallée) / Online (Zoom)"
+---
+
+**IEEE ITSS France Chapter Talk Series**
+
+Prof. Saeid Saidi (University of Calgary) will give a seminar on recent advances in public transit operations, control, and planning, with an emphasis on analytical modeling, optimization, and mobility sensing data.
+
+## Event Details
+
+| | |
+|---|---|
+| **Speaker** | Prof. Saeid Saidi, Associate Professor, Department of Civil Engineering, University of Calgary |
+| **Date** | Tuesday, May 12, 2026 |
+| **Time** | 21:00–23:00 KST / 14:00–16:00 CEST |
+| **Format** | Hybrid (in-person and online) |
+| **Venue** | Salle A121, Bâtiment Bienvenüe, Université Gustave Eiffel, GRETTIA Laboratory, Marne-la-Vallée |
+| **Organizer** | IEEE ITSS France Chapter |
+
+## Topic
+
+Recent advances in public transit operations, control, and planning, with emphasis on analytical modeling, optimization, and mobility sensing data. A discussion session will follow the presentation.
+
+## How to Join
+
+- **Zoom Link:** [Join Meeting](https://univ-eiffel.zoom.us/j/84245369690) (Passcode: eHa5rUHf)
+- **Meeting ID:** 842 4536 9690
+- See also the [IEEE ITSS France Chapter LinkedIn announcement](https://www.linkedin.com/posts/join-our-cloud-hd-video-meeting-share-7457427931783630849-FEGF).
+
+The seminar is open to researchers, academics, students, professionals, and practitioners in Intelligent Transportation Systems, transit operations, mobility data analytics, and transport network design.
+
+> **Note:** The original announcement listed CET, but May 12 falls within European summer time (DST began March 29, 2026), so CEST applies. Please double-check the exact time closer to the event.

--- a/content/events/2026-05-france-talk-saidi.ko.md
+++ b/content/events/2026-05-france-talk-saidi.ko.md
@@ -1,0 +1,37 @@
+---
+title: "France Chapter Talk Series — Saeid Saidi 교수"
+date: 2026-05-12
+draft: false
+description: "IEEE ITSS France Chapter Talk Series: 대중교통 운영·제어·계획의 최신 연구 동향, Saeid Saidi 교수. 2026년 5월 12일, 하이브리드."
+event_date: "2026년 5월 12일 (화) 21:00 KST / 14:00 CEST"
+location: "하이브리드 — Université Gustave Eiffel (Marne-la-Vallée) / 온라인 (Zoom)"
+---
+
+**IEEE ITSS France Chapter Talk Series**
+
+Saeid Saidi 교수(University of Calgary)가 대중교통 운영·제어·계획에 관한 최신 연구를 발표합니다. 분석 모델링, 최적화, 모빌리티 센싱 데이터에 중점을 둘 예정입니다.
+
+## 행사 정보
+
+| | |
+|---|---|
+| **발표자** | Saeid Saidi 교수, University of Calgary 토목공학과 부교수 |
+| **일시** | 2026년 5월 12일 (화) |
+| **시간** | 21:00–23:00 KST / 14:00–16:00 CEST |
+| **형식** | 하이브리드 (현장 + 온라인) |
+| **장소** | Salle A121, Bâtiment Bienvenüe, Université Gustave Eiffel, GRETTIA Laboratory, Marne-la-Vallée |
+| **주최** | IEEE ITSS France Chapter |
+
+## 주제
+
+대중교통 운영·제어·계획 분야의 최신 연구 동향. 분석 모델링, 최적화, 모빌리티 센싱 데이터 활용을 중심으로 다루며, 발표 후에는 토론 세션이 이어집니다.
+
+## 참가 방법
+
+- **Zoom 링크:** [회의 참가](https://univ-eiffel.zoom.us/j/84245369690) (암호: eHa5rUHf)
+- **회의 ID:** 842 4536 9690
+- [IEEE ITSS France Chapter LinkedIn 공지](https://www.linkedin.com/posts/join-our-cloud-hd-video-meeting-share-7457427931783630849-FEGF)도 참고하시기 바랍니다.
+
+지능 교통 시스템(ITS), 대중교통 운영, 모빌리티 데이터 분석, 교통망 설계 분야의 연구자·학생·실무자 모두에게 열려 있습니다.
+
+> **참고:** 원 공지에는 CET로 표기되어 있으나, 5월 12일은 유럽 서머타임(2026년 3월 29일 시작) 적용 기간이므로 CEST가 맞습니다. 행사 임박 시점에 정확한 시간을 다시 확인해 주세요.


### PR DESCRIPTION
## Summary
- Adds the May 12, 2026 IEEE ITSS France Chapter Talk Series seminar by Prof. Saeid Saidi (University of Calgary) on recent advances in public transit operations, control, and planning.
- Hybrid event at Université Gustave Eiffel (Marne-la-Vallée) and Zoom.
- Source: [LinkedIn announcement](https://www.linkedin.com/posts/join-our-cloud-hd-video-meeting-share-7457427931783630849-FEGF).

## Notes
- Time normalized from "CET" in the original announcement to **CEST** (May 12 falls in European summer time); KST = 21:00–23:00. Same convention as the Haddad DL event.

## Test plan
- [x] `hugo` builds without errors
- [x] Event renders on EN and KO homepages under Upcoming Events
- [ ] Verify rendered times once deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)