### PR TITLE
Relabel single-page date by section: 행사일/Event date on events, 게시일/Posted on on news

### DIFF
--- a/i18n/en.toml
+++ b/i18n/en.toml
@@ -75,6 +75,9 @@ other = "Back to list"
 [event_date]
 other = "Date"
 
+[event_date_label]
+other = "Event date"
+
 [event_location]
 other = "Location"
 

--- a/i18n/ko.toml
+++ b/i18n/ko.toml
@@ -75,6 +75,9 @@ other = "목록으로"
 [event_date]
 other = "일시"
 
+[event_date_label]
+other = "행사일"
+
 [event_location]
 other = "장소"
 

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -4,7 +4,7 @@
 
     <header class="content-header">
       {{ if .Date }}
-      <time class="content-date">{{ i18n "posted_on" }}: {{ .Date.Format "2006-01-02" }}</time>
+      <time class="content-date">{{ if eq .Section "events" }}{{ i18n "event_date_label" }}{{ else }}{{ i18n "posted_on" }}{{ end }}: {{ .Date.Format "2006-01-02" }}</time>
       {{ end }}
       <h1>{{ .Title }}</h1>
       {{ with .Params.subtitle }}<p class="content-subtitle">{{ . }}</p>{{ end }}


### PR DESCRIPTION
## Problem

`layouts/_default/single.html` rendered every page's `date:` field with the label `posted_on` ("게시일 / Posted on"). But **event** pages set front-matter `date:` to the *event start date* (e.g. ICVES `date: 2026-11-09`, ITSC `date: 2026-09-15`, DL Levin `date: 2026-06-10`). So on events this rendered e.g. **"게시일: 2026-11-09"** — labeling a (future) conference date as the posting date, which is wrong and confusing.

## Fix (section-aware label)

Make the date label depend on the section:
- **events** → "행사일 / Event date"
- everything else (news, etc.) → "게시일 / Posted on" (unchanged)

Section detection uses `{{ if eq .Section "events" }}`, matching the existing convention already used elsewhere in this same template (the event-meta block at line 14).

Adds a new i18n key `event_date_label` (ko = "행사일", en = "Event date"). Note: the pre-existing `event_date` key (ko = "일시", en = "Date") is the label for the human-readable `.Params.event_date` string in the event-meta block and is **left untouched** — reusing that key would have changed the meta label and (as a duplicate) broken the TOML, so a distinct key was needed.

## Why news keeps 게시일

Spot-checked `content/news/`: every news post sets `date:` to the genuine announcement date (chapter-established 2025-12-02, awards-nominations 2026-02-06, itsc2025-best-paper-videos 2025-12-15, 3mt-introduction 2026-05-11). Deadlines/event dates live in body text, never in `date:`. So "게시일" remains correct for news.

## Verification

`hugo --gc` builds clean. Rendered output confirmed:
- Event KO `행사일: 2026-11-09`, EN `Event date: 2026-11-09`
- News KO `게시일: 2026-05-11`, EN `Posted on: 2026-05-11`

Files changed: `layouts/_default/single.html`, `i18n/ko.toml`, `i18n/en.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)