### PR TITLE
Make ICVES 2026 event pages accurate: precise venue, theme, CfP/author links, paper format

### DIFF
--- a/content/events/2026-11-icves.en.md
+++ b/content/events/2026-11-icves.en.md
@@ -2,14 +2,16 @@
 title: "ICVES 2026 — IEEE International Conference on Vehicular Electronics and Safety"
 date: 2026-11-09
 draft: false
-description: "The 20th IEEE ICVES. November 9–11, 2026, Cochabamba, Bolivia. Paper submission deadline: July 19, 2026."
+description: "The 20th IEEE ICVES. November 9–11, 2026, UNIVALLE, Tiquipaya, Cochabamba, Bolivia. Paper submission deadline: July 19, 2026."
 event_date: "November 9–11, 2026"
-location: "Cochabamba, Bolivia"
+location: "Universidad Privada del Valle (UNIVALLE), Tiquipaya, Cochabamba, Bolivia"
 ---
 
 **ICVES 2026** is the 20th edition of the **IEEE International Conference on Vehicular Electronics and Safety**, an annual forum sponsored by the IEEE Intelligent Transportation Systems Society (ITSS). It serves as a premier interdisciplinary platform for researchers, practitioners, and policymakers to present and discuss the latest advances in intelligent vehicular electronics and safety.
 
-This year's edition spotlights the evolving landscape of vehicular electronics, intelligent systems, and safety technologies, with particular emphasis on innovations and unique solutions emerging from Latin America and their resonance around the world.
+This year's edition spotlights the evolving landscape of vehicular electronics, intelligent systems, and safety technologies, with particular emphasis on innovations and unique solutions emerging from Latin America and their resonance around the world. The conference theme is **"Advancing Safe, Inclusive and Sustainable Mobility in Emerging Road Ecosystems."**
+
+The conference will be held at **Universidad Privada del Valle (UNIVALLE)** in **Tiquipaya, Cochabamba, Bolivia**.
 
 ## Important Dates
 
@@ -27,7 +29,7 @@ Topics of interest include vehicular safety, accident-prevention technologies, d
 
 ## Paper Submission
 
-- Accepted papers will be published in IEEE Xplore.
-- Papers may be delivered as either long or short interactive presentations, including poster sessions.
+- Accepted papers will be published in IEEE Xplore and may be delivered as either long or short interactive presentations, including poster sessions.
+- Papers should follow the official IEEE conference templates. The expected length is 6 pages, with a maximum of 8 pages (the 2 extra pages incur additional page charges).
 
-For full details, the call for papers, and submission instructions, visit the [ICVES 2026 official website](https://ieee-icves.org/2026/).
+For full details, see the [Call for Papers](https://ieee-icves.org/2026/contributions/call-for-papers/) and the [Information for Authors](https://ieee-icves.org/2026/contributions/information-for-authors/) pages.

--- a/content/events/2026-11-icves.ko.md
+++ b/content/events/2026-11-icves.ko.md
@@ -2,14 +2,16 @@
 title: "ICVES 2026 — IEEE International Conference on Vehicular Electronics and Safety"
 date: 2026-11-09
 draft: false
-description: "제20회 IEEE ICVES. 2026년 11월 9–11일, 볼리비아 코차밤바. 논문 투고 마감: 2026년 7월 19일."
+description: "제20회 IEEE ICVES. 2026년 11월 9–11일, 볼리비아 코차밤바 티키파야 UNIVALLE. 논문 투고 마감: 2026년 7월 19일."
 event_date: "2026년 11월 9–11일"
-location: "볼리비아 코차밤바 (Cochabamba, Bolivia)"
+location: "Universidad Privada del Valle (UNIVALLE), 볼리비아 코차밤바 티키파야 (Tiquipaya, Cochabamba, Bolivia)"
 ---
 
 **ICVES 2026**은 제20회 **IEEE International Conference on Vehicular Electronics and Safety**로, IEEE Intelligent Transportation Systems Society (ITSS)가 후원하는 연례 학술대회입니다. 지능형 차량 전자 및 안전 분야의 최신 연구 성과를 연구자, 실무자, 정책 입안자가 함께 발표하고 논의하는 대표적인 학제 간 플랫폼 역할을 합니다.
 
-올해 대회는 차량 전자, 지능형 시스템, 안전 기술의 변화하는 흐름을 조명하며, 특히 라틴 아메리카에서 등장하는 혁신과 독창적 해법, 그리고 그것이 전 세계에 미치는 반향에 중점을 둡니다.
+올해 대회는 차량 전자, 지능형 시스템, 안전 기술의 변화하는 흐름을 조명하며, 특히 라틴 아메리카에서 등장하는 혁신과 독창적 해법, 그리고 그것이 전 세계에 미치는 반향에 중점을 둡니다. 대회 주제는 **"Advancing Safe, Inclusive and Sustainable Mobility in Emerging Road Ecosystems(신흥 도로 생태계에서 안전하고 포용적이며 지속 가능한 모빌리티의 발전)"**입니다.
+
+대회는 볼리비아 코차밤바 티키파야의 **Universidad Privada del Valle (UNIVALLE)**에서 개최됩니다.
 
 ## 주요 일정
 
@@ -27,7 +29,7 @@ location: "볼리비아 코차밤바 (Cochabamba, Bolivia)"
 
 ## 논문 투고
 
-- 채택된 논문은 IEEE Xplore에 게재됩니다.
-- 논문은 포스터 세션을 포함하여 장(long) 또는 단(short) 형식의 대화형 발표로 진행될 수 있습니다.
+- 채택된 논문은 IEEE Xplore에 게재되며, 포스터 세션을 포함하여 장(long) 또는 단(short) 형식의 대화형 발표로 진행될 수 있습니다.
+- 논문은 공식 IEEE 학술대회 템플릿을 따라야 합니다. 권장 분량은 6쪽이며 최대 8쪽까지 허용됩니다(추가 2쪽에는 추가 페이지 요금이 부과됩니다).
 
-자세한 내용, 논문 모집 공고(call for papers) 및 투고 안내는 [ICVES 2026 공식 웹사이트](https://ieee-icves.org/2026/)를 참고해 주시기 바랍니다.
+자세한 내용은 [논문 모집 공고(Call for Papers)](https://ieee-icves.org/2026/contributions/call-for-papers/) 및 [저자 안내(Information for Authors)](https://ieee-icves.org/2026/contributions/information-for-authors/) 페이지를 참고해 주시기 바랍니다.


### PR DESCRIPTION
Updates the bilingual ICVES 2026 event pages with verified facts from the official ICVES 2026 sources (invitation letter, CFP flyer, and Call for Papers / Information for Authors pages). No fabricated or carried-over claims.

## Changes (en + ko, kept parallel)
- **Precise venue** — `Universidad Privada del Valle (UNIVALLE), Tiquipaya, Cochabamba, Bolivia` in `location:` front matter, `description:`, and body. *Source: official invitation letter.*
- **Conference theme** — "Advancing Safe, Inclusive and Sustainable Mobility in Emerging Road Ecosystems." *Source: CFP flyer.*
- **Authoritative links** — replaced the single home-page link with [Call for Papers](https://ieee-icves.org/2026/contributions/call-for-papers/) and [Information for Authors](https://ieee-icves.org/2026/contributions/information-for-authors/). *Source: official site.*
- **Paper format** — 6 pages expected, up to 8 (2 extra pages with additional charges); official IEEE conference templates. *Source: Information for Authors page (verbatim).*

Important Dates table already matched the verified dates (Jul 19 STRICT / Aug 23 / Sep 1 reg / Sep 30 camera-ready / Nov 9–11), so it was left unchanged.

`draft: false` and `date: 2026-11-09` preserved. Local `hugo --gc --minify` build passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)