### PR TITLE
Style list pagination as a horizontal pager

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -540,3 +540,44 @@ ul, ol { padding-left: 1.5em; }
 
   .footer-grid { grid-template-columns: 1fr; }
 }
+
+/* --- Pagination (events / news list pages) --- */
+.pagination {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  align-items: center;
+  gap: 0.4rem;
+  padding: 0;
+  margin: 2.5rem 0 0.5rem;
+}
+.pagination .page-item { margin: 0; }
+.pagination .page-link {
+  display: inline-block;
+  min-width: 2.4rem;
+  padding: 0.45rem 0.7rem;
+  text-align: center;
+  line-height: 1;
+  color: var(--ieee-blue);
+  background: var(--bg-white);
+  border: 1px solid var(--border-color);
+  border-radius: var(--radius);
+  transition: background 0.2s, color 0.2s;
+}
+.pagination .page-link:hover {
+  background: var(--ieee-blue-light);
+  color: var(--ieee-blue-dark);
+  text-decoration: none;
+}
+.pagination .page-item.active .page-link {
+  background: var(--ieee-blue);
+  border-color: var(--ieee-blue);
+  color: #fff;
+}
+.pagination .page-item.disabled .page-link {
+  color: var(--text-muted);
+  background: var(--bg-light);
+  pointer-events: none;
+  opacity: 0.6;
+}


### PR DESCRIPTION
The events list now spans 2 pages (15 events), so Hugo shows its pager — but `layouts/_default/list.html` calls `_internal/pagination.html` (Bootstrap-style `<ul class="pagination">`), and the theme had **no CSS for it**, so it rendered as a default **vertical bulleted list**.

This adds `.pagination` rules to `static/css/style.css` (using the existing IEEE-blue palette + `--border-color` / `--radius`): a centered, **bullet-free horizontal pager** with hover, **active** (current page), and **disabled** (first/prev on page 1) states.

Pure additive CSS — no markup or content change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)