### PR TITLE
Publish unlisted ExCom 2026-05-29 page

### DIFF
--- a/content/excom/2026-05-29.en.md
+++ b/content/excom/2026-05-29.en.md
@@ -1,0 +1,38 @@
+---
+title: "ExCom Meeting — 2026-05-29"
+date: 2026-05-29
+draft: true
+description: "IEEE ITSS Korea Chapter Executive Committee (ExCom) meeting — May 29, 2026. (Unlisted working page.)"
+---
+
+> **Unlisted working page.** Not linked from any menu or list, and kept as a `draft`, so it is not published to the live site. (Local preview: `hugo server -D`.)
+
+## 1. Agenda
+
+- [to fill]
+- [to fill]
+- [to fill]
+
+## 2. Upcoming Chapter Events
+
+| Date | Event | Location |
+|------|-------|----------|
+| 2026-06-10/11 | Distinguished Lecture — Dr. Tomas Levin | Online |
+| 2026-06-22–25 | IV 2026 (IEEE Intelligent Vehicles Symposium) | Detroit, Michigan, USA |
+| 2026-06-23 | Chapter Meeting #2 — IV 2026 Korean Networking Dinner | Daebak Korean BBQ, Southfield, MI |
+| 2026-09-15–18 | ITSC 2026 | Naples, Italy (Stazione Marittima) |
+| 2026-09 | ITSS Hackathon @ ITSC 2026 — Smart Mobility Data Challenge | Naples (during ITSC 2026) |
+| 2026-11-09–11 | ICVES 2026 | Cochabamba, Bolivia (UNIVALLE) |
+| 2027-06-15–18 | IV 2027 | Perth, Western Australia |
+
+*See the chapter website's Events pages for full details.*
+
+## 3. Discussion & Decisions
+
+- [to fill]
+
+## 4. Action Items
+
+| Item | Owner | Due |
+|------|-------|-----|
+| [to fill] | | |

--- a/content/excom/2026-05-29.en.md
+++ b/content/excom/2026-05-29.en.md
@@ -1,7 +1,7 @@
 ---
 title: "ExCom Meeting — 2026-05-29"
 date: 2026-05-29
-draft: true
+draft: false
 description: "IEEE ITSS Korea Chapter Executive Committee (ExCom) meeting — May 29, 2026. (Unlisted working page.)"
 ---
 

--- a/content/excom/2026-05-29.ko.md
+++ b/content/excom/2026-05-29.ko.md
@@ -1,0 +1,38 @@
+---
+title: "운영위원회 회의 — 2026-05-29"
+date: 2026-05-29
+draft: true
+description: "IEEE ITSS Korea Chapter 운영위원회(ExCom) 회의 — 2026년 5월 29일. (비공개 작업용 페이지)"
+---
+
+> **비공개 작업용 페이지입니다.** 메뉴·목록에 연결되어 있지 않으며, `draft` 상태이므로 공개 사이트에는 게시되지 않습니다. (로컬 미리보기: `hugo server -D`)
+
+## 1. 안건 / Agenda
+
+- [채울 내용]
+- [채울 내용]
+- [채울 내용]
+
+## 2. 다가오는 챕터 행사 / Upcoming Chapter Events
+
+| 일자 | 행사 | 장소 |
+|------|------|------|
+| 2026-06-10~11 | Distinguished Lecture — Dr. Tomas Levin | 온라인 |
+| 2026-06-22~25 | IV 2026 (IEEE Intelligent Vehicles Symposium) | 미국 미시건 디트로이트 |
+| 2026-06-23 | 챕터 미팅 #2 — IV 2026 한인 네트워킹 디너 | Daebak Korean BBQ, Southfield, MI |
+| 2026-09-15~18 | ITSC 2026 | 이탈리아 나폴리 (Stazione Marittima) |
+| 2026-09 | ITSS Hackathon @ ITSC 2026 — Smart Mobility Data Challenge | 나폴리 (ITSC 2026 기간 중) |
+| 2026-11-09~11 | ICVES 2026 | 볼리비아 코차밤바 (UNIVALLE) |
+| 2027-06-15~18 | IV 2027 | 호주 퍼스 |
+
+*상세 내용은 챕터 웹사이트의 Events 페이지를 참고하십시오.*
+
+## 3. 논의 · 결정 사항 / Discussion & Decisions
+
+- [채울 내용]
+
+## 4. 후속 조치 / Action Items
+
+| 항목 | 담당 | 기한 |
+|------|------|------|
+| [채울 내용] | | |

--- a/content/excom/2026-05-29.ko.md
+++ b/content/excom/2026-05-29.ko.md
@@ -1,7 +1,7 @@
 ---
 title: "운영위원회 회의 — 2026-05-29"
 date: 2026-05-29
-draft: true
+draft: false
 description: "IEEE ITSS Korea Chapter 운영위원회(ExCom) 회의 — 2026년 5월 29일. (비공개 작업용 페이지)"
 ---
 


### PR DESCRIPTION
Adds an **unlisted** ExCom working page for the 2026-05-29 Korea Chapter Executive Committee meeting.

- Non-menu `excom/` section → not in nav, not in any linked list.
- `draft:false` so it is reachable by direct URL:
  - KO: https://ieee-itss-korea.github.io/web/ko/excom/2026-05-29/
  - EN: https://ieee-itss-korea.github.io/web/excom/2026-05-29/
- Pre-fills the upcoming-events table from existing event pages; agenda / decisions / action-items are fillable placeholders.

Build verified locally (hugo --gc --minify + fix-language-paths.sh). No edits to existing pages.