### PR TITLE
Add unlisted 3MT introduction page

### DIFF
--- a/content/news/2026-05-3mt-introduction.en.md
+++ b/content/news/2026-05-3mt-introduction.en.md
@@ -1,0 +1,20 @@
+---
+title: "Three Minute Thesis (3MT) — A New Direction for Member Communication Skills"
+date: 2026-05-11
+description: "Korea Chapter introduces the Three Minute Thesis (3MT) format as a future member-development activity, complementing the ITSS Best Dissertation Award."
+build:
+  render: always
+  list: never
+---
+
+The Korea Chapter is introducing the **Three Minute Thesis (3MT®)** format to its members as a future activity for research-communication skill development.
+
+Originated at the University of Queensland in 2008, 3MT challenges graduate researchers to explain their work to a non-specialist audience in **three minutes, with a single static slide**. No additional media, props, or instruments — spoken word only. The format is now run at hundreds of institutions worldwide.
+
+We see 3MT as a strong fit for **recent PhDs and master's degree holders** in the ITS community. The ability to convey complex research clearly to a broad audience is increasingly central to both academic and industry careers, and the 3MT discipline — one slide, three minutes, plain language — sharpens exactly that skill.
+
+The Chapter is exploring how to introduce 3MT as a structured activity in coming cycles. Members interested in the format are encouraged to view example presentations on the [official 3MT site](https://threeminutethesis.uq.edu.au/) and share thoughts via our LinkedIn Group.
+
+---
+
+The Chapter also continues to keep the [ITSS Best Dissertation Award](https://ieee-itss.org/awards/) — the Society-level recognition for outstanding doctoral research in ITS — visible to qualifying members.

--- a/content/news/2026-05-3mt-introduction.ko.md
+++ b/content/news/2026-05-3mt-introduction.ko.md
@@ -1,0 +1,20 @@
+---
+title: "Three Minute Thesis (3MT) — 회원 소통 역량 강화의 새로운 방향"
+date: 2026-05-11
+description: "Korea Chapter는 ITSS Best Dissertation Award를 보완하는 향후 회원 활동으로 Three Minute Thesis (3MT) 형식을 소개합니다."
+build:
+  render: always
+  list: never
+---
+
+Korea Chapter는 회원 여러분의 연구 소통 역량 개발을 위한 향후 활동으로 **Three Minute Thesis (3MT®)** 형식을 소개합니다.
+
+3MT는 2008년 University of Queensland에서 시작된 발표 대회 형식으로, 대학원 연구자가 자신의 연구를 비전공 청중에게 **3분 안에, 정적 슬라이드 한 장**만으로 설명합니다. 추가 매체, 도구, 영상은 허용되지 않으며 오직 말로만 전달합니다. 현재 전 세계 수백 개 기관에서 운영되고 있습니다.
+
+복잡한 연구 내용을 폭넓은 청중에게 명확히 전달하는 능력은 학계와 산업계 모두에서 점점 더 중요해지고 있으며, **최근 박사 및 석사 학위 취득자**에게 3MT 형식 — 슬라이드 한 장, 3분, 평이한 언어 — 은 그 역량을 다듬는 좋은 훈련 기회가 될 수 있다고 봅니다.
+
+Chapter는 향후 활동 주기에서 3MT를 어떤 방식으로 도입할지 검토 중입니다. 관심 있는 회원께서는 [공식 3MT 사이트](https://threeminutethesis.uq.edu.au/)에서 예시 발표 영상을 시청하시고, LinkedIn Group을 통해 의견을 공유해 주시기 바랍니다.
+
+---
+
+또한 Chapter는 ITS 분야 박사 논문에 대한 Society 차원의 인정인 [ITSS Best Dissertation Award](https://ieee-itss.org/awards/)를 자격을 갖춘 회원 여러분께 지속적으로 안내드리고 있습니다.


### PR DESCRIPTION
Publishes the **Three Minute Thesis (3MT)** introduction page for the Korea Chapter, **unlisted**.

- Bilingual pair under `content/news/`, kept off the news list / homepage / nav / RSS via `build.list: never` (renders at its URL only).
- Reachable URLs:
  - KO: https://ieee-itss-korea.github.io/web/ko/news/2026-05-3mt-introduction/
  - EN: https://ieee-itss-korea.github.io/web/en/news/2026-05-3mt-introduction/

Build verified locally (clean `hugo --gc --minify`; confirmed the page renders but does not appear in any list). No edits to existing pages.