### PR TITLE
IV 2026 dinner: location → TBA (near conference venue)

### DIFF
--- a/content/events/2026-06-networking-dinner.en.md
+++ b/content/events/2026-06-networking-dinner.en.md
@@ -4,7 +4,7 @@ date: 2026-06-23
 draft: false
 description: "Korean networking dinner for IV 2026 attendees in Detroit on June 23, 2026 (17:30–20:30 EDT). Hosted by the IEEE ITSS Korea Chapter. Registration closes June 16, 2026."
 event_date: "June 23, 2026 (Tue) 17:30–20:30 EDT (Detroit local)"
-location: "Daebak Korean BBQ, 27566 Northwestern Hwy, Southfield, MI 48034, USA"
+location: "To be announced (near the conference venue)"
 ---
 
 **IEEE ITSS Korea Chapter Meeting #2 — IV 2026 Korean Networking Dinner @ Detroit**
@@ -19,7 +19,7 @@ Held alongside the **IEEE Intelligent Vehicles Symposium (IV 2026)** in Detroit,
 |---|---|
 | **Date** | Tuesday, June 23, 2026 |
 | **Time** | 17:30–20:30 EDT (Detroit local) — equivalent to Wed, June 24, 06:30–09:30 KST |
-| **Venue** | Daebak Korean BBQ, 27566 Northwestern Hwy, Southfield, MI 48034, USA |
+| **Venue** | To be announced (near the conference venue) |
 | **Fee** | Approx. USD $40–50 per person, paid on the day (no member / non-member distinction) |
 | **Who should attend** | Korean researchers, engineers, and graduate students attending IV 2026; Korea Chapter members welcome |
 | **Organizer** | IEEE Korea Council Chapter ITSS38 |

--- a/content/events/2026-06-networking-dinner.ko.md
+++ b/content/events/2026-06-networking-dinner.ko.md
@@ -4,7 +4,7 @@ date: 2026-06-23
 draft: false
 description: "IV 2026 참석자를 위한 한국인 네트워킹 디너 — 2026년 6월 23일 디트로이트에서 개최 (현지 17:30–20:30 EDT). IEEE ITSS 한국 지회 주최. 등록 마감은 2026년 6월 16일입니다."
 event_date: "2026년 6월 23일 (화) 17:30–20:30 EDT (디트로이트 현지 시각)"
-location: "Daebak Korean BBQ, 27566 Northwestern Hwy, Southfield, MI 48034, USA"
+location: "추후 공지 (학술대회장 인근)"
 ---
 
 **IEEE ITSS 한국 지회 2차 모임 — IV 2026 한국인 네트워킹 디너 @ 디트로이트**
@@ -19,7 +19,7 @@ location: "Daebak Korean BBQ, 27566 Northwestern Hwy, Southfield, MI 48034, USA"
 |---|---|
 | **일자** | 2026년 6월 23일 (화) |
 | **시간** | 17:30–20:30 EDT (디트로이트 현지 시각) — 한국 시각 기준 6월 24일 (수) 06:30–09:30 KST |
-| **장소** | Daebak Korean BBQ, 27566 Northwestern Hwy, Southfield, MI 48034, USA |
+| **장소** | 추후 공지 (학술대회장 인근) |
 | **참가비** | 1인당 약 USD $40–50, 당일 현장 결제 (회원/비회원 구분 없음) |
 | **참가 대상** | IV 2026에 참석하는 한국인 연구자·엔지니어·대학원생; 한국 지회 회원 환영 |
 | **주최** | IEEE Korea Council Chapter ITSS38 |


### PR DESCRIPTION
Per ExCom 2026-05-29: the IV 2026 Korea Chapter dinner is being simplified and relocated closer to the conference venue. New venue not yet selected, so this softens the live event page (was *Daebak KBBQ, Southfield*) to **추후 공지 (학술대회장 인근) / To be announced (near the conference venue)** in both languages (front matter + details table). Time/format/fee to be updated once the venue is confirmed.