### PR TITLE
Add co-promoted seminar event: Prof. Houbing Song (VTS Seoul / KU BK21), Jun 29 at Korea University Sejong, hybrid

### DIFF
--- a/content/events/2026-06-seminar-houbing-song.en.md
+++ b/content/events/2026-06-seminar-houbing-song.en.md
@@ -1,0 +1,48 @@
+---
+title: "Seminar — Neuro-symbolic AI for Trustworthy Systems in Intelligent Transportation Systems (Prof. Houbing H. Song)"
+date: 2026-06-29
+draft: false
+description: "Shared with our members: a seminar hosted by the IEEE VTS Seoul Section Chapter and Korea University BK21 IoT Data Science. Prof. Houbing H. Song (University of Maryland, USA), June 29, 2026 at Korea University Sejong Campus, hybrid. Registration closes June 28, 2026."
+event_date: "Monday, June 29, 2026, 16:00–17:30 KST"
+location: "Room 310, 3rd Floor, Sci & Tech Bldg II, Korea University Sejong Campus"
+speaker: "Prof. Houbing H. Song (University of Maryland, USA)"
+---
+
+**Seminar — Neuro-symbolic AI for Trustworthy Systems in Intelligent Transportation Systems**
+
+This seminar is **hosted by the IEEE VTS Seoul Section Chapter and Korea University BK21 IoT Data Science**, and is shared here for our members. It is **not** hosted or sponsored by the IEEE ITSS Korea Chapter — we are passing it along at the hosts' invitation. Prof. Houbing H. Song (University of Maryland, USA) speaks on "Neuro-symbolic AI for Trustworthy Systems in Intelligent Transportation Systems." The seminar is hybrid — held in person and online via Zoom.
+
+> **Registration closes Sunday, June 28, 2026.** To attend, email your **name, affiliation, and email address** to **Prof. Minho Jo at minhojo@korea.ac.kr** before the deadline. The Zoom link is emailed to registrants.
+>
+> *The official registration channel is Prof. Jo's email; the IEEE ITSS Korea Chapter is only sharing this announcement.*
+
+## Event Details
+
+| | |
+|---|---|
+| **Date & time** | Monday, June 29, 2026, 16:00–17:30 KST |
+| **Venue** | Room 310, 3rd Floor, Science & Technology Building II, Korea University Sejong Campus |
+| **Format** | Hybrid — in person and online via Zoom |
+| **Speaker** | Prof. Houbing H. Song, University of Maryland, USA |
+| **Hosts** | IEEE VTS Seoul Section Chapter · Korea University BK21 IoT Data Science |
+
+## Abstract
+
+Neuro-symbolic AI integrates neural networks with symbolic reasoning to bring explainability, reliability, and adaptability to complex transportation systems, enabling trust in autonomous and cyber-physical systems. In this talk, Prof. Song presents his perspective on emerging neuro-symbolic AI for trustworthy systems, particularly in Intelligent Transportation Systems.
+
+## Speaker
+
+**Prof. Houbing H. Song** (University of Maryland, USA) is an IEEE Fellow, ACM Distinguished Member, and IEEE Distinguished Lecturer, and Director of the **SONG Lab** (security, cyber-physical systems, IoT, AI). He is an Associate Editor of *IEEE Transactions on Intelligent Transportation Systems* and Co-Editor-in-Chief of *IEEE Transactions on Industrial Informatics*, and has been a Highly Cited Researcher from 2021 to the present (h-index 101). He received his PhD in Electrical Engineering from the University of Virginia in 2012.
+
+## How to Register
+
+- **Registration deadline:** Sunday, June 28, 2026
+- **How to register:** Email your **name, affiliation, and email address** to **Prof. Minho Jo at minhojo@korea.ac.kr**.
+- The Zoom link is emailed to registrants once registration is complete.
+- Registration is handled through Prof. Jo's email; there is no separate sign-up through the IEEE ITSS Korea Chapter.
+
+## Contact
+
+For questions about registering or attending the seminar, please contact the host, **Prof. Minho Jo at minhojo@korea.ac.kr**, directly.
+
+For questions about the IEEE ITSS Korea Chapter, reach the Chapter Chair, **Kangwon Lee** — [contact form](https://forms.gle/zFyReJdxHULLFrEY8) (registration itself is via Prof. Jo's email).

--- a/content/events/2026-06-seminar-houbing-song.ko.md
+++ b/content/events/2026-06-seminar-houbing-song.ko.md
@@ -1,0 +1,48 @@
+---
+title: "세미나 안내 — Neuro-symbolic AI for Trustworthy Systems in Intelligent Transportation Systems (Prof. Houbing H. Song)"
+date: 2026-06-29
+draft: false
+description: "IEEE VTS Seoul Section Chapter와 고려대학교 BK21 IoT Data Science가 주최하는 세미나를 회원 여러분께 안내드립니다. Prof. Houbing H. Song (University of Maryland, USA), 2026년 6월 29일 (월) 고려대학교 세종캠퍼스, 하이브리드. 등록 마감 2026년 6월 28일 (일)."
+event_date: "2026년 6월 29일 (월) 16:00–17:30 KST"
+location: "고려대학교 세종캠퍼스 과학기술II관 3층 310호"
+speaker: "Prof. Houbing H. Song (University of Maryland, USA)"
+---
+
+**세미나 안내 — Neuro-symbolic AI for Trustworthy Systems in Intelligent Transportation Systems**
+
+**IEEE VTS Seoul Section Chapter**와 **고려대학교 BK21 IoT Data Science**가 주최하는 세미나를 회원 여러분께 안내드립니다. 본 세미나는 IEEE ITSS 한국 지회가 주최·후원하는 행사가 아니며, 주최 측의 안내에 따라 회원 여러분께 공유드리는 것임을 알려드립니다. Prof. Houbing H. Song (University of Maryland, USA)께서 「Neuro-symbolic AI for Trustworthy Systems in Intelligent Transportation Systems」를 주제로 강연하시며, 현장과 온라인(Zoom)으로 동시에 진행되는 하이브리드 행사입니다.
+
+> **등록 마감: 2026년 6월 28일 (일).** 참가를 원하시는 분은 마감일 전까지 **성명·소속·이메일 주소**를 적어 고려대학교 **조민호 교수님(minhojo@korea.ac.kr)** 께 이메일로 보내 주시기 바랍니다. 등록하신 분께는 Zoom 링크가 이메일로 전달됩니다.
+>
+> *본 세미나의 공식 등록 창구는 조민호 교수님 이메일이며, IEEE ITSS 한국 지회는 안내만 드립니다.*
+
+## 행사 정보
+
+| | |
+|---|---|
+| **일시** | 2026년 6월 29일 (월) 16:00–17:30 KST |
+| **장소** | 고려대학교 세종캠퍼스 과학기술II관 3층 310호 |
+| **진행 방식** | 하이브리드 — 현장 참석 및 온라인(Zoom) 참석 |
+| **연사** | Prof. Houbing H. Song, University of Maryland, USA |
+| **주최** | IEEE VTS Seoul Section Chapter · 고려대학교 BK21 IoT Data Science |
+
+## 초록
+
+Neuro-symbolic AI는 신경망(neural networks)과 기호 추론(symbolic reasoning)을 결합하여, 복잡한 교통 시스템에 설명 가능성(explainability), 신뢰성(reliability), 적응성(adaptability)을 부여하는 접근입니다. 이를 통해 자율주행 및 사이버-물리 시스템(cyber-physical systems)에 대한 신뢰를 확보할 수 있습니다. 본 강연에서 Prof. Song은 신뢰할 수 있는 시스템을 위한 neuro-symbolic AI, 특히 지능형 교통 시스템(Intelligent Transportation Systems) 분야에서의 전망을 제시합니다.
+
+## 연사 소개
+
+**Prof. Houbing H. Song** (University of Maryland, USA)은 IEEE Fellow, ACM Distinguished Member, IEEE Distinguished Lecturer이며, 보안·사이버-물리 시스템·IoT·AI를 연구하는 **SONG Lab**의 디렉터입니다. *IEEE Transactions on Intelligent Transportation Systems*의 Associate Editor, *IEEE Transactions on Industrial Informatics*의 Co-Editor-in-Chief를 맡고 있으며, 2021년부터 현재까지 Highly Cited Researcher로 선정되었습니다 (h-index 101). 2012년 University of Virginia에서 전기공학(Electrical Engineering) 박사 학위를 받았습니다.
+
+## 참가 방법
+
+- **등록 마감:** 2026년 6월 28일 (일)
+- **등록 방법:** **성명·소속·이메일 주소**를 적어 고려대학교 **조민호 교수님(minhojo@korea.ac.kr)** 께 이메일로 보내 주시기 바랍니다.
+- 등록을 완료하신 분께 Zoom 링크가 이메일로 전달됩니다.
+- 본 세미나의 등록 창구는 조민호 교수님 이메일이며, IEEE ITSS 한국 지회를 통한 별도 등록 절차는 없습니다.
+
+## 문의
+
+세미나 등록·참가에 관한 문의는 주최 측인 고려대학교 **조민호 교수님(minhojo@korea.ac.kr)** 께 직접 연락해 주시기 바랍니다.
+
+IEEE ITSS 한국 지회 관련 문의는 지회장 **이강원** — [문의 폼](https://forms.gle/zFyReJdxHULLFrEY8) 으로 보내 주시기 바랍니다 (등록 접수는 조민호 교수님 이메일로 진행됩니다).


### PR DESCRIPTION
## Summary

Adds a paired `.ko`/`.en` event page under `content/events/` for a seminar the Korea Chapter is **announcing on behalf of its hosts** — it is **not** an ITSS-hosted or ITSS-sponsored event.

- `content/events/2026-06-seminar-houbing-song.ko.md`
- `content/events/2026-06-seminar-houbing-song.en.md`

Both are `draft: false` with the full event front matter (`event_date`, `location`, `speaker`). Structure follows the existing event pages (3MT / networking dinner): host-credit intro paragraph, registration blockquote callout, an 행사 정보 / Event Details table, abstract, speaker bio, and a 참가 방법 / How to Register section.

## Host-credit framing

The page leads with, and repeats, that the seminar is **hosted by the IEEE VTS Seoul Section Chapter and Korea University BK21 IoT Data Science**, and that the IEEE ITSS Korea Chapter is only sharing the announcement. The 문의 / Contact section points primary registration at the host (Prof. Minho Jo's email) and keeps the chapter inquiry form as a chapter-only fallback — no implication that ITSS registers attendees or owns the event.

## Sourced facts (from the official poster)

- **Title:** Neuro-symbolic AI for Trustworthy Systems in Intelligent Transportation Systems
- **Speaker:** Prof. Houbing H. Song, University of Maryland, USA — IEEE Fellow, ACM Distinguished Member, IEEE Distinguished Lecturer; Director of the SONG Lab; AE of *IEEE T-ITS*; Co-EiC of *IEEE T-II*; Highly Cited Researcher (2021–present), h-index 101; PhD EE, University of Virginia (2012)
- **When:** Monday, June 29, 2026, 16:00–17:30 KST
- **Where:** Room 310, 3rd Floor, Science & Technology Building II, Korea University Sejong Campus
- **Format:** Hybrid — in person + online via Zoom
- **Registration:** by June 28, 2026 — email name + affiliation + email to Prof. Minho Jo (minhojo@korea.ac.kr); Zoom link emailed to registrants
- **Hosts:** IEEE VTS Seoul Section Chapter & Korea University BK21 IoT Data Science

## Build check

Local production build (`hugo --gc --minify`, TZ=Asia/Seoul) succeeds; the new pages render in both languages. `scripts/fix-language-paths.sh` mirrors the EN page to `/en/`, and `scripts/verify-build.sh` passes (only the expected `HUGO_DEPLOY_SHA not set` local-build warning). No changes to `verify-build.sh` needed — nothing renamed or removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)