### PR TITLE
Add CIV Summer School 2026 and ITSS/SC webinar (Dr. Nick Reed) as cross-promo events

### DIFF
--- a/content/events/2026-06-itss-sc-webinar.en.md
+++ b/content/events/2026-06-itss-sc-webinar.en.md
@@ -1,0 +1,38 @@
+---
+title: "ITSS Standards Committee Webinar — What Does It Mean to Be a Good Driver? (Dr. Nick Reed)"
+date: 2026-06-25
+draft: false
+description: "IEEE ITSS Standards Committee Webinar #7: 'What does it mean to be a good driver?' by Dr. Nick Reed (Reed Mobility). June 25, 2026, Online (Webex)."
+event_date: "Thursday, June 25, 2026 — 16:00 BST / 17:00 CET / 15:00 UTC (00:00 KST, June 26)"
+location: "Online (Webex)"
+---
+
+**IEEE ITSS Standards Committee Webinar Series (7th webinar)**
+
+Dr. Nick Reed presents on the emerging regulation of automated vehicles and a standardised approach to data collection from automated vehicles.
+
+## Event Details
+
+| | |
+|---|---|
+| **Title** | What does it mean to be a good driver? |
+| **Speaker** | Dr. Nick Reed — Director, Reed Mobility (UK); former Chief Road Safety Adviser to National Highways |
+| **Date** | Thursday, June 25, 2026 |
+| **Time** | 16:00 BST / 17:00 CET / 15:00 UTC (00:00 KST, June 26) |
+| **Format** | Online (Webex) |
+| **Organizer** | IEEE ITSS Standards Committee (ITSS/SC) |
+
+## Abstract
+
+Dr. Reed will speak on the emerging regulation of automated vehicles on public roads and the potential for a standardised approach to data collection from automated vehicles — assessing driving behaviour against legally defined requirements.
+
+## How to Join
+
+- **Webex Link:** [Join Webinar](https://ieeesa.webex.com/ieeesa/j.php?MTID=m08df6fa7d58927ecd03f3a30fd0d6322)
+- **Meeting number:** 2337 365 8258
+
+## Contact
+
+- Dr. Meng Lu, IEEE ITSS/SC Chair
+- Dr. Javier Ibanez-Guzman, IEEE ITSS/SC Vice Chair
+- Dr. Ayesha Choudhary, IEEE ITSS/SC Secretary

--- a/content/events/2026-06-itss-sc-webinar.ko.md
+++ b/content/events/2026-06-itss-sc-webinar.ko.md
@@ -1,0 +1,38 @@
+---
+title: "ITSS 표준위원회 웨비나 — 좋은 운전자란 무엇인가? (Dr. Nick Reed)"
+date: 2026-06-25
+draft: false
+description: "IEEE ITSS 표준위원회 제7회 웨비나: 'What does it mean to be a good driver?' — Dr. Nick Reed (Reed Mobility). 2026년 6월 25일, 온라인 (Webex)."
+event_date: "2026년 6월 25일 (목) — 16:00 BST / 17:00 CET / 15:00 UTC (한국시각 6월 26일 00:00)"
+location: "온라인 (Webex)"
+---
+
+**IEEE ITSS 표준위원회 웨비나 시리즈 (제7회)**
+
+Dr. Nick Reed가 자율주행차의 도로 운행 규제 동향과 자율주행차 데이터 수집의 표준화 방안에 대해 발표합니다.
+
+## 행사 개요
+
+| | |
+|---|---|
+| **제목** | What does it mean to be a good driver? (좋은 운전자란 무엇인가?) |
+| **연사** | Dr. Nick Reed — Reed Mobility(영국) 대표; 전 National Highways 도로안전 수석자문 |
+| **일시** | 2026년 6월 25일 (목) |
+| **시각** | 16:00 BST / 17:00 CET / 15:00 UTC (한국시각 6월 26일 00:00) |
+| **형식** | 온라인 (Webex) |
+| **주관** | IEEE ITSS 표준위원회 (ITSS/SC) |
+
+## 초록
+
+Dr. Reed는 공공도로에서의 자율주행차 규제 동향과, 법적으로 정의된 요건에 따라 주행 행동을 평가하기 위한 자율주행차 데이터 수집의 표준화 가능성에 대해 발표합니다.
+
+## 참가 안내
+
+- **Webex 링크:** [웨비나 참가](https://ieeesa.webex.com/ieeesa/j.php?MTID=m08df6fa7d58927ecd03f3a30fd0d6322)
+- **회의 번호:** 2337 365 8258
+
+## 문의
+
+- Dr. Meng Lu, IEEE ITSS/SC 위원장
+- Dr. Javier Ibanez-Guzman, IEEE ITSS/SC 부위원장
+- Dr. Ayesha Choudhary, IEEE ITSS/SC 간사

--- a/content/events/2026-08-civ-summer-school.en.md
+++ b/content/events/2026-08-civ-summer-school.en.md
@@ -1,0 +1,41 @@
+---
+title: "CIV Summer School 2026 — Cooperative Interacting Vehicles (Miyazaki, Japan)"
+date: 2026-08-31
+draft: false
+description: "6th Summer School on Cooperative Interacting Vehicles (CIV), supported by IEEE ITSS. Aug 31 – Sep 4, 2026, Miyazaki, Japan. For PhD students and early-career researchers. First application deadline June 22, 2026."
+event_date: "August 31 – September 4, 2026"
+location: "Miyazaki, Japan (in person)"
+---
+
+The IEEE ITSS Korea Chapter shares the **CIV Summer School 2026**, supported by IEEE ITSS — an opportunity of interest to Korean Ph.D. students and early-career researchers.
+
+## Event Details
+
+| | |
+|---|---|
+| **Event** | 6th Summer School on Cooperative Interacting Vehicles (CIV) |
+| **Dates** | August 31 – September 4, 2026 |
+| **Location** | Miyazaki, Japan (in person) |
+| **For** | Ph.D. students & early-career researchers/professionals (academia, research institutions, industry) |
+| **Organizers** | MINES ParisTech (PSL University), Karlsruhe Institute of Technology, UC Berkeley, University of Tokyo, German University in Cairo — with Heex Technologies |
+| **Support** | IEEE Intelligent Transportation Systems Society (IEEE ITSS) |
+
+## Topics
+
+- Cooperative perception and motion planning
+- Implicit and explicit interaction
+- Modeling and data-driven methods (including AI)
+
+## Fees
+
+- Academic students: ¥160,000
+- Industry / other professionals: ¥220,000
+- Single-room upgrade (academic students only): +¥60,000
+
+## How to Apply
+
+- **First application deadline:** June 22, 2026 (applications open through August 21, 2026)
+- **Website:** [civ-summerschool.org](https://civ-summerschool.org)
+- **Application form:** [Apply here](https://tlab-utokyo.notion.site/345b648fbda680178a9ccd3078e1db1c)
+
+*This event is organized by the institutions listed above and supported by IEEE ITSS. The IEEE ITSS Korea Chapter shares it as a community opportunity.*

--- a/content/events/2026-08-civ-summer-school.ko.md
+++ b/content/events/2026-08-civ-summer-school.ko.md
@@ -1,0 +1,41 @@
+---
+title: "CIV Summer School 2026 — 협력 상호작용 차량 여름학교 (일본 미야자키)"
+date: 2026-08-31
+draft: false
+description: "IEEE ITSS가 후원하는 제6회 협력 상호작용 차량(CIV) 여름학교. 2026년 8월 31일 ~ 9월 4일, 일본 미야자키. 박사과정생 및 신진 연구자 대상. 1차 지원 마감 2026년 6월 22일."
+event_date: "2026년 8월 31일 ~ 9월 4일"
+location: "일본 미야자키 (현장 진행)"
+---
+
+IEEE ITSS 한국 지회가 IEEE ITSS 후원 행사인 **CIV Summer School 2026** 소식을 공유합니다. 한국의 박사과정생과 신진 연구자에게 좋은 기회입니다.
+
+## 행사 개요
+
+| | |
+|---|---|
+| **행사** | 제6회 협력 상호작용 차량(CIV) 여름학교 |
+| **일시** | 2026년 8월 31일 ~ 9월 4일 |
+| **장소** | 일본 미야자키 (현장 진행) |
+| **대상** | 박사과정생 및 신진 연구자·실무자 (대학·연구기관·산업계) |
+| **주관** | MINES ParisTech (PSL), Karlsruhe Institute of Technology, UC Berkeley, 도쿄대학, German University in Cairo — Heex Technologies 지원 |
+| **후원** | IEEE Intelligent Transportation Systems Society (IEEE ITSS) |
+
+## 주제
+
+- 협력 인지 및 동작 계획
+- 명시적·암묵적 상호작용
+- 데이터 기반 모델링 (AI 포함)
+
+## 참가비
+
+- 학생(학계): ¥160,000
+- 산업계·기타: ¥220,000
+- 1인실 추가(학생 한정): +¥60,000
+
+## 지원 안내
+
+- **1차 지원 마감:** 2026년 6월 22일 (접수는 8월 21일까지)
+- **웹사이트:** [civ-summerschool.org](https://civ-summerschool.org)
+- **지원서:** [지원하기](https://tlab-utokyo.notion.site/345b648fbda680178a9ccd3078e1db1c)
+
+*본 행사는 위 기관들이 주관하고 IEEE ITSS가 후원합니다. IEEE ITSS 한국 지회는 커뮤니티 기회로서 이를 공유합니다.*


### PR DESCRIPTION
Adds two cross-promotion event pages (bilingual .en/.ko, draft:false):

- **2026-06-itss-sc-webinar** — IEEE ITSS Standards Committee webinar #7, "What does it mean to be a good driver?" by Dr. Nick Reed (Reed Mobility), Thu Jun 25 2026, online (Webex). Same series as the existing 2026-02 / 2026-03 SC webinar pages.
- **2026-08-civ-summer-school** — 6th Summer School on Cooperative Interacting Vehicles, Miyazaki Japan, Aug 31 - Sep 4 2026, supported by IEEE ITSS; first application deadline Jun 22.

Both framed as cross-promotions: organizing bodies + IEEE ITSS credited, chapter amplifying. event_date + location set per the events taxonomy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)