### PR TITLE
Add news: KAIST wins First Prize Best Student Paper Award at IEEE IV 2026

### DIFF
--- a/content/news/2026-06-iv2026-best-student-paper.en.md
+++ b/content/news/2026-06-iv2026-best-student-paper.en.md
@@ -1,0 +1,13 @@
+---
+title: "KAIST Team Wins First Prize Best Student Paper Award at IEEE IV 2026"
+date: 2026-06-26
+description: "A KAIST research team received the First Prize Best Student Paper Award at the 2026 IEEE Intelligent Vehicles Symposium (IV 2026) in Detroit."
+---
+
+A research team from KAIST received the **First Prize Best Student Paper Award** at the **2026 IEEE Intelligent Vehicles Symposium (IV 2026)**, held in Detroit, USA, in June 2026.
+
+The award-winning paper, *"Development of an Active Aerodynamic System for Improving Circuit Driving Performance of High-Performance Electric Vehicles,"* was presented by **Sungwon Nah** of the KAIST Unmanned Systems Research Group (USRG), led by **Prof. David Hyunchul Shim**, and was conducted as a joint research effort with **Hyundai Motor Company**.
+
+Selected for an oral presentation, the work combines wind-tunnel aerodynamic modeling, real-time control, and full-scale circuit testing to show that a multi-surface active aerodynamic system can significantly improve lap time, braking, cornering, and vehicle stability under limit-driving conditions.
+
+The IEEE ITSS Korea Chapter extends its warm congratulations to the awardee, his advisor, and the USRG and Hyundai Motor Company team on this outstanding achievement.

--- a/content/news/2026-06-iv2026-best-student-paper.ko.md
+++ b/content/news/2026-06-iv2026-best-student-paper.ko.md
@@ -1,0 +1,13 @@
+---
+title: "KAIST 연구팀, IEEE IV 2026 최우수 학생 논문상(First Prize) 수상"
+date: 2026-06-26
+description: "KAIST 연구팀이 2026 IEEE Intelligent Vehicles Symposium (IV 2026, 미국 디트로이트)에서 최우수 학생 논문상(First Prize Best Student Paper Award)을 수상했습니다."
+---
+
+KAIST 연구팀이 2026년 6월 미국 디트로이트에서 개최된 **2026 IEEE Intelligent Vehicles Symposium (IV 2026)**에서 **최우수 학생 논문상(First Prize, Best Student Paper Award)**을 수상했습니다.
+
+수상 논문 *"Development of an Active Aerodynamic System for Improving Circuit Driving Performance of High-Performance Electric Vehicles"*는 KAIST 무인시스템 및 제어 연구실(USRG, 지도교수 **심현철(David Hyunchul Shim) 교수**)의 **나성원** 연구원이 발표하였으며, **현대자동차와의 공동 연구**로 수행되었습니다.
+
+구두 발표(Oral Presentation) 논문으로 선정된 본 연구는 풍동 기반 공력 모델링, 실시간 제어, 실차 서킷 실험을 결합하여 다중 표면 능동 공력 시스템이 랩타임, 제동, 코너링, 한계 주행 안정성을 크게 향상시킬 수 있음을 입증하였습니다.
+
+IEEE ITSS Korea Chapter는 수상자와 지도교수, 그리고 USRG 및 현대자동차 연구진께 진심으로 축하의 말씀을 전합니다.


### PR DESCRIPTION
Adds a bilingual (EN/KO) news post announcing that a KAIST team received the **First Prize Best Student Paper Award** at IEEE IV 2026 (Detroit, June 2026).

- Awardee: **Sungwon Nah** — KAIST Unmanned Systems Research Group (USRG) / 무인시스템 및 제어 연구실, advisor **Prof. David Hyunchul Shim**
- Paper: *Development of an Active Aerodynamic System for Improving Circuit Driving Performance of High-Performance Electric Vehicles* (oral; joint research with **Hyundai Motor Company**)

Notes for review:
- Placed in `content/news/` (announcement, not an event) with plain `title/date/description` front matter — no `event_date`/`location`, no `draft:`, per repo convention.
- Korean uses **공동 연구** and lab name **무인시스템 및 제어 연구실 (USRG)**; please confirm the lab-name rendering and the awardee hangul (**나성원**).
- EN keeps the established English name "Unmanned Systems Research Group (USRG)"; flag if you'd like EN/KO expansions aligned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)