### PR TITLE
Add cross-promo event page: ITSS webinar on autonomous driving systems (Aug 6)

### DIFF
--- a/content/events/2026-08-itss-webinar-ads.en.md
+++ b/content/events/2026-08-itss-webinar-ads.en.md
@@ -1,0 +1,41 @@
+---
+title: "ITSS Webinar — Advances with Autonomous Driving Systems"
+date: 2026-08-06
+draft: false
+description: "IEEE ITSS Webinar: Advances with Autonomous Driving Systems — Perspectives and Innovation from the Vehicle and the Roadside. Dr. Yan Wang (NVIDIA) and Prof. Henry Liu (University of Michigan). August 6, 2026, Online (Webex)."
+event_date: "August 6, 2026 (Thu) 11:00–12:00 EDT / August 7 (Fri) 00:00–01:00 KST"
+location: "Online (Webex)"
+speaker: "Dr. Yan Wang (NVIDIA) & Prof. Henry Liu (University of Michigan)"
+---
+
+**IEEE ITSS Webinar**
+
+The IEEE Intelligent Transportation Systems Society (ITSS) invites you to a webinar on advances in autonomous driving systems, examining innovation from two complementary vantage points — the vehicle and the roadside.
+
+## Event Details
+
+| | |
+|---|---|
+| **Title** | Advances with Autonomous Driving Systems: Perspectives and Innovation from the Vehicle and the Roadside |
+| **Speakers** | Dr. Yan Wang (NVIDIA) · Prof. Henry Liu (University of Michigan) |
+| **Date** | Thursday, August 6, 2026 |
+| **Time** | 11:00–12:00 EDT / 00:00–01:00 KST (Fri, Aug 7) |
+| **Format** | Online (Webex) |
+| **Organizer** | IEEE ITSS — Educational Activities |
+
+## About the Webinar
+
+Autonomous driving is advancing on two fronts at once. On board the **vehicle**, increasingly capable perception, prediction, and planning stacks are expanding what a single automated vehicle can sense and decide. From the **roadside**, infrastructure-based sensing and connectivity extend perception beyond the line of sight of any one vehicle and enable cooperative, system-level intelligence. This webinar brings together perspectives from industry and academia on how these two vantage points are evolving — and converging.
+
+*The full abstract and speaker details are available on the registration page.*
+
+## How to Join
+
+- **Register:** [Webex registration](https://ieee.webex.com/weblink/register/r1995476600ba135daf5b4c1f1bed4089)
+- Registered participants receive the Webex access details before the event.
+
+For more information, visit the [IEEE Intelligent Transportation Systems Society](http://www.ieee-itss.org/) website.
+
+---
+
+*This is an IEEE ITSS Society webinar that we are sharing with our members. For those in Korea, the live session falls at 00:00–01:00 KST on Friday, August 7 — registering ensures you receive any follow-up materials even if you cannot join live.*

--- a/content/events/2026-08-itss-webinar-ads.ko.md
+++ b/content/events/2026-08-itss-webinar-ads.ko.md
@@ -1,0 +1,41 @@
+---
+title: "ITSS 웨비나 — 자율주행 시스템의 최신 발전"
+date: 2026-08-06
+draft: false
+description: "IEEE ITSS 웨비나: 자율주행 시스템의 최신 발전 — 차량과 노변의 관점과 혁신. Dr. Yan Wang (NVIDIA), Prof. Henry Liu (University of Michigan). 2026년 8월 6일, 온라인 (Webex)."
+event_date: "2026년 8월 6일 (목) 11:00–12:00 EDT / 8월 7일 (금) 00:00–01:00 KST"
+location: "온라인 (Webex)"
+speaker: "Dr. Yan Wang (NVIDIA) & Prof. Henry Liu (University of Michigan)"
+---
+
+**IEEE ITSS 웨비나**
+
+IEEE 지능형교통시스템 학회(ITSS)가 자율주행 시스템의 최신 발전을 다루는 웨비나에 여러분을 초대합니다. 이번 웨비나는 차량(vehicle)과 노변(roadside), 상호 보완적인 두 관점에서 자율주행 기술의 혁신을 조망합니다.
+
+## 행사 정보
+
+| | |
+|---|---|
+| **제목** | Advances with Autonomous Driving Systems: Perspectives and Innovation from the Vehicle and the Roadside |
+| **연사** | Dr. Yan Wang (NVIDIA) · Prof. Henry Liu (University of Michigan) |
+| **일시** | 2026년 8월 6일 (목) |
+| **시간** | 11:00–12:00 EDT / 8월 7일 (금) 00:00–01:00 KST |
+| **형식** | 온라인 (Webex) |
+| **주최** | IEEE ITSS — Educational Activities |
+
+## 웨비나 소개
+
+자율주행 기술은 두 방향에서 동시에 발전하고 있습니다. **차량** 측에서는 인지·예측·계획 기술이 지속적으로 향상되며 단일 자율주행차가 감지하고 판단할 수 있는 범위를 넓히고 있습니다. **노변(roadside)** 측에서는 인프라 기반 센싱과 연결성이 개별 차량의 가시거리를 넘어서는 인지를 가능하게 하고, 협력형·시스템 차원의 지능을 구현합니다. 이번 웨비나에서는 산업계와 학계의 시각을 통해 이 두 관점이 어떻게 발전하고 수렴하는지를 살펴봅니다.
+
+*상세 초록과 연사 소개는 등록 페이지에서 확인하실 수 있습니다.*
+
+## 참가 방법
+
+- **등록:** [Webex 등록](https://ieee.webex.com/weblink/register/r1995476600ba135daf5b4c1f1bed4089)
+- 등록하신 참가자에게는 행사 전 Webex 접속 정보가 안내됩니다.
+
+자세한 내용은 [IEEE Intelligent Transportation Systems Society](http://www.ieee-itss.org/) 웹사이트를 참고해 주세요.
+
+---
+
+*본 행사는 IEEE ITSS 학회가 주최하는 웨비나로, 회원 여러분께 공유드립니다. 한국 기준 실시간 진행 시각은 8월 7일 (금) 00:00–01:00 (KST)입니다. 등록해 두시면 실시간 참석이 어려우시더라도 후속 자료를 안내받으실 수 있습니다.*


### PR DESCRIPTION
Cross-promotes the IEEE ITSS Society webinar **Advances with Autonomous Driving Systems — Perspectives and Innovation from the Vehicle and the Roadside** (Dr. Yan Wang, NVIDIA; Prof. Henry Liu, University of Michigan), **Aug 6, 2026, 11:00–12:00 EDT** (= 00:00–01:00 KST, Aug 7), online via Webex.

- New paired event pages `content/events/2026-08-itss-webinar-ads.{en,ko}.md`, `draft: false`.
- Shared-event framing (Society webinar, not chapter-hosted) with the closing "we're sharing this" note.
- KST-midnight timing called out so members register for the recording rather than expecting live attendance.
- Webex registration link included.

Source: IEEE eNotice, on behalf of Xiaopeng (Shaw) Li, ITSS Interim VP of Educational Activities.

Note: the eNotice spells the second presenter "Henry Lui"; used "Henry Liu" (University of Michigan) as the standard spelling — revert if the organizers intend otherwise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)